### PR TITLE
Parse branch from repo url

### DIFF
--- a/components/repository-selection-card.tsx
+++ b/components/repository-selection-card.tsx
@@ -19,6 +19,31 @@ interface RepositorySelectionCardProps {
   showHeader?: boolean
 }
 
+// Helper function to parse GitHub URLs and extract branch information
+function parseGitHubUrl(url: string): { cleanUrl: string; extractedBranch?: string } {
+  // Check if URL includes branch information (tree/branch-name)
+  const branchMatch = url.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)\/tree\/([^/]+)(?:\/.*)?$/)
+  
+  if (branchMatch) {
+    const [, baseUrl, branchName] = branchMatch
+    return {
+      cleanUrl: baseUrl,
+      extractedBranch: branchName
+    }
+  }
+  
+  // Regular GitHub URL without branch - just clean it up
+  const cleanMatch = url.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)(?:\.git)?(?:\/)?$/)
+  if (cleanMatch) {
+    return {
+      cleanUrl: cleanMatch[1]
+    }
+  }
+  
+  // Return as-is if it doesn't match expected patterns
+  return { cleanUrl: url }
+}
+
 export default function RepositorySelectionCard({
   title = "Bootstrap Chat from GitHub",
   description = "Initialize a new v0 chat instance from a public GitHub repository.",
@@ -34,6 +59,20 @@ export default function RepositorySelectionCard({
   const [isFetchingBranches, setIsFetchingBranches] = useState(false)
   const [branchError, setBranchError] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [extractedBranch, setExtractedBranch] = useState<string | undefined>(undefined)
+
+  // Handle repo URL input changes with branch extraction
+  const handleRepoUrlChange = (value: string) => {
+    const { cleanUrl, extractedBranch } = parseGitHubUrl(value)
+    
+    setRepoUrl(cleanUrl)
+    setExtractedBranch(extractedBranch)
+    
+    // If we extracted a branch, show a helpful message
+    if (extractedBranch && extractedBranch !== selectedBranch) {
+      toast.info(`Detected branch "${extractedBranch}" in URL`)
+    }
+  }
 
   // Debounce repo URL changes
   useEffect(() => {
@@ -44,6 +83,7 @@ export default function RepositorySelectionCard({
         setBranches([])
         setSelectedBranch("")
         setBranchError("")
+        setExtractedBranch(undefined)
       }
     }, 500)
 
@@ -61,13 +101,31 @@ export default function RepositorySelectionCard({
 
       if (result.success && result.branches) {
         setBranches(result.branches)
-        // Prioritize "main" over "master", then fall back to first branch
-        const defaultBranch =
-          result.branches.find((branch) => branch === "main") ||
-          result.branches.find((branch) => branch === "master") ||
-          result.branches[0]
+        
+        // Determine default branch priority:
+        // 1. Extracted branch from URL (if it exists in the repository)
+        // 2. "main" branch
+        // 3. "master" branch  
+        // 4. First branch in the list
+        let defaultBranch: string
+        
+        if (extractedBranch && result.branches.includes(extractedBranch)) {
+          defaultBranch = extractedBranch
+          toast.success(`Using branch "${extractedBranch}" from URL`)
+        } else {
+          defaultBranch =
+            result.branches.find((branch) => branch === "main") ||
+            result.branches.find((branch) => branch === "master") ||
+            result.branches[0]
+          
+          if (extractedBranch && !result.branches.includes(extractedBranch)) {
+            toast.warning(`Branch "${extractedBranch}" not found. Using "${defaultBranch}" instead.`)
+          } else {
+            toast.success(`Found ${result.branches.length} branches`)
+          }
+        }
+        
         setSelectedBranch(defaultBranch)
-        toast.success(`Found ${result.branches.length} branches`)
       } else {
         setBranchError(result.error || "Failed to fetch branches")
         toast.error(result.error || "Failed to fetch branches")
@@ -128,9 +186,14 @@ export default function RepositorySelectionCard({
               type="url"
               disabled={disabled || isSubmitting}
               value={repoUrl}
-              onChange={(e) => setRepoUrl(e.target.value)}
+              onChange={(e) => handleRepoUrlChange(e.target.value)}
               className="h-12 text-base"
             />
+            {extractedBranch && (
+              <p className="text-sm text-muted-foreground">
+                Detected branch: <span className="font-medium text-primary">{extractedBranch}</span>
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
Automatically parse GitHub repository URLs to extract and pre-select branch names, improving user experience when pasting full branch links.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf8500a5-9944-42b4-9fcf-099e14d72cff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf8500a5-9944-42b4-9fcf-099e14d72cff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>